### PR TITLE
Update gst-go to tagged version v0.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/lucas-clemente/quic-go v0.28.1
-	github.com/mengelbart/gst-go v0.0.0-20220824124234-80d4e9fbbda6
+	github.com/mengelbart/gst-go v0.0.2
 	github.com/mengelbart/scream-go v0.4.1-0.20220916152424-a421761640a2
 	github.com/mengelbart/syncodec v0.0.0-20220105132658-94ec57e63a65
 	github.com/pion/interceptor v0.1.12

--- a/go.sum
+++ b/go.sum
@@ -297,8 +297,8 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mengelbart/gst-go v0.0.0-20220824124234-80d4e9fbbda6 h1:tvyh8lLqLoS1JxTggnFepVvLyY8MTtPZr6zKoQFEiyU=
-github.com/mengelbart/gst-go v0.0.0-20220824124234-80d4e9fbbda6/go.mod h1:J9js686VBdevB5wQODy0ZTDtUsMipxoSpedYVXsJ1vU=
+github.com/mengelbart/gst-go v0.0.2 h1:75BwkD34Dxf/yeXb+N7zwtjDmoiit9vu5yt8g2oZeNE=
+github.com/mengelbart/gst-go v0.0.2/go.mod h1:J9js686VBdevB5wQODy0ZTDtUsMipxoSpedYVXsJ1vU=
 github.com/mengelbart/quic-go v0.7.1-0.20220916195640-e314b18dd0a4 h1:SNxmKQp84YDnqnNslza1E4Trp8t9DYc607Zx/tnF3Jo=
 github.com/mengelbart/quic-go v0.7.1-0.20220916195640-e314b18dd0a4/go.mod h1:CTcNfLYJS2UuRNB+zcNlgvkjBhxX6Hm3WUxxAQx2mgE=
 github.com/mengelbart/rtp v1.7.14-0.20220728010821-271390af6fab h1:1CHgU3Xf+kSJcl6K4LtPjsVo1XSGMuS6FNkSeDNrptk=


### PR DESCRIPTION
includes:

* general refactoring
* revert from g_memdup2 back to g_memdup for compatibility with older versions of glib